### PR TITLE
Make handleError helper pure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 4
   - 5
   - 6
-  - "stable"
 cache:
   directories:
     - node_modules

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,30 @@
+import VError from 'verror';
+import { ROLLBAR_REQ_FIELDS } from './constants';
+
+// Take a single Error or array of Errors and return an array of errors that
+// have message prefixed.
+export function handleError(err, prefix = 'RollbarSourceMapPlugin') {
+  if (!err) {
+    return [];
+  }
+
+  const errors = [].concat(err);
+  return errors.map(e => new VError(e, prefix));
+}
+
+// Validate required options and return an array of errors or null if there
+// are no errors.
+export function validateOptions(ref) {
+  const errors = ROLLBAR_REQ_FIELDS.reduce((result, field) => {
+    if (ref && ref.hasOwnProperty(field)) {
+      return result;
+    }
+
+    return [
+      ...result,
+      new Error(`required field, '${field}', is missing.`)
+    ];
+  }, []);
+
+  return errors.length ? errors : null;
+}

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+import { ROLLBAR_REQ_FIELDS } from '../src/constants';
+import * as helpers from '../src/helpers';
+
+describe('helpers', function() {
+  describe('handleError', function() {
+    it('should return an array of length 1 given a single error', function() {
+      const result = helpers.handleError(new Error('required field missing'));
+      expect(result).to.be.an('array').with.lengthOf(1);
+    });
+
+    it('should return an array of length 2 given an array of length 2', function() {
+      const result = helpers.handleError([
+        new Error('required field missing'),
+        new Error('request failed')
+      ]);
+      expect(result)
+        .to.be.an('array')
+        .and.to.have.lengthOf(2);
+    });
+
+    it('should prefix message of single error', function() {
+      const result = helpers.handleError(new Error('required field missing'), 'Plugin');
+      expect(result[0]).to.have.property('message',
+        'Plugin: required field missing'
+      );
+    });
+
+    it('should prefix message of an array of errors', function() {
+      const result = helpers.handleError([
+        new Error('required field missing'),
+        new Error('request failed')
+      ], 'Plugin');
+      expect(result[0]).to.have.property('message',
+        'Plugin: required field missing'
+      );
+      expect(result[1]).to.have.property('message',
+        'Plugin: request failed'
+      );
+    });
+
+    it('should default prefix to "RollbarSourceMapPlugin"', function() {
+      const result = helpers.handleError(new Error('required field missing'));
+      expect(result[0]).to.have.property('message',
+        'RollbarSourceMapPlugin: required field missing'
+      );
+    });
+
+    it('should handle null', function() {
+      const result = helpers.handleError(null);
+      expect(result).to.eql([]);
+    });
+
+    it('should handle empty []', function() {
+      const result = helpers.handleError([]);
+      expect(result).to.eql([]);
+    });
+  });
+
+  describe('validateOptions', function() {
+    it('should return null if all required options are supplied', function() {
+      const options = {
+        accessToken: 'aaabbbccc000111',
+        version: 'latest',
+        publicPath: 'https://my.cdn.net/assets'
+      };
+      const result = helpers.validateOptions(options);
+      expect(result).to.be.null; // eslint-disable-line no-unused-expressions
+    });
+
+    it('should return an error if accessToken is not supplied', function() {
+      const options = {
+        version: 'latest',
+        publicPath: 'https://my.cdn.net/assets'
+      };
+      const result = helpers.validateOptions(options);
+      expect(result).to.be.an('array').with.lengthOf(1);
+      expect(result[0])
+        .to.be.an('error')
+        .with.property('message', 'required field, \'accessToken\', is missing.');
+    });
+
+    it('should return an error if version is not supplied', function() {
+      const options = {
+        accessToken: 'aaabbbccc000111',
+        publicPath: 'https://my.cdn.net/assets'
+      };
+      const result = helpers.validateOptions(options);
+      expect(result).to.be.an('array').with.lengthOf(1);
+      expect(result[0])
+        .to.be.an('error')
+        .with.property('message', 'required field, \'version\', is missing.');
+    });
+
+    it('should handle multiple missing required options', function() {
+      const options = {};
+      const result = helpers.validateOptions(options);
+      expect(result).to.be.an('array').with.lengthOf(ROLLBAR_REQ_FIELDS.length);
+    });
+
+    it('should handle null for options', function() {
+      const result = helpers.validateOptions(null);
+      expect(result).to.be.an('array').with.lengthOf(ROLLBAR_REQ_FIELDS.length);
+    });
+
+    it('should handle no options passed', function() {
+      const result = helpers.validateOptions();
+      expect(result).to.be.an('array').with.lengthOf(ROLLBAR_REQ_FIELDS.length);
+    });
+  });
+});


### PR DESCRIPTION
- This function was taking the webpack compilation as an arg and pushing errors
onto the errors property. So it was mutating an arg. Made this pure so that it
returns an array of prefixed error and the caller can push them onto the
compilation errors.

- Split out handlerError and validateOptions into a seperate helpers file and add
tests.

- Remove "stable" node build in ci.