### PR TITLE
Add an example for React

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,5 +15,10 @@
     "func-names": 0,
     "prefer-arrow-callback": 0,
     "space-before-function-paren": 0
+  },
+  "globals": {
+    // Constants defined in examples webpack.config
+    "__ROLLBAR_ACCESS_TOKEN__": true,
+    "__GIT_REVISION__": true
   }
 }

--- a/.npmignore
+++ b/.npmignore
@@ -5,5 +5,6 @@ test
 examples
 docs
 tmp
+examples
 coverage.lcov
 .nyc_output

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ Allowed values are as follows:
 - `version`: *(required)* A string identifying the version of your code this source map package is for.
   Typically this will be the full git sha.
 - `publicPath`: *(required)* The base url for the cdn where your production bundles are hosted.
-- `includeChunks`: An array of chunks for which sourcemaps should be uploaded.
+- `includeChunks`: *(optional)* An array of chunks for which sourcemaps should be uploaded.
   This should correspond to the names in the webpack config `entry` field.
-  If there's only one chunk, it can be a string rather than an array. In not supplied,
+  If there's only one chunk, it can be a string rather than an array. If not supplied,
   all sourcemaps emitted by webpack will be uploaded.
-- `silent`: `true | false` If `true`, success messages will be logged to the console for each upload.
-   defaults to `false`.
+- `silent`: *(optional)* `true | false` If `true`, success messages will be logged to the console for each upload.
+   Defaults to `false`.
 
 App Configuration
 --------------------
@@ -65,3 +65,22 @@ App Configuration
   for how to configure the client side for sourcemap support.
   The `code_version` parameter must match the `version` parameter used for the plugin.
 - More general info on the using [Rollbar for browser JS](https://rollbar.com/doc`s/notifier/rollbar.js/).
+
+Examples
+--------
+- React [(source)](https://github.com/brandondoran/rollbar-sourcemap-webpack-plugin/tree/master/examples/react)
+A minimal single page app with webpack build. The app includes a local Express server that
+serves an index.html. The build is meant to mimic a production build in that js bundles and sourcemaps are uploaded
+to AWS S3. You will need AWS and Rollbar accounts. To run the example:
+
+  - Set your aws and rollbar options in `examples/react/webpack.config.babel.js`
+  - `$ cd examples/react`
+  - `$ npm run build`
+  - `$ npm start`
+  - open [http://localhost:8000](http://localhost:8000/)
+  
+  When the example app is loaded in a browser,
+  the app will throw an error, which will be sent to Rollbar.
+  You should be able to log in to Rollbar and see the error with stacktrace
+  with line numbers that map to the original source.
+	

--- a/examples/react/.babelrc
+++ b/examples/react/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react", "es2015", "stage-0"]
+}

--- a/examples/react/index.js
+++ b/examples/react/index.js
@@ -1,0 +1,2 @@
+require('babel-register');
+require('./server');

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "rollbar-sourcemap-webpack-plugin-react-example",
+  "version": "1.0.0",
+  "description": "React Example for RollbarSourceMapPlugin",
+  "main": "index.js",
+  "scripts": {
+    "clean": "rimraf dist",
+    "prebuild": "npm run -s clean",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "cross-env NODE_ENV='production' webpack --progress --profile --colors",
+    "start": "cross-env NODE_ENV='production' node index"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/brandondoran/rollbar-sourcemap-webpack-plugin.git"
+  },
+  "keywords": [
+    "react",
+    "example",
+    "rollbar",
+    "sourcemap",
+    "webpack",
+    "plugin"
+  ],
+  "author": "Brandon Doran <bdoran@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/brandondoran/rollbar-sourcemap-webpack-plugin/issues"
+  },
+  "homepage": "https://github.com/brandondoran/rollbar-sourcemap-webpack-plugin#readme",
+  "dependencies": {
+    "react": "^15.0.2",
+    "react-dom": "^15.0.2",
+    "rollbar-browser": "^1.9.1"
+  },
+  "devDependencies": {
+    "babel-core": "^6.8.0",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-register": "^6.8.0",
+    "cross-env": "^1.0.7",
+    "express": "^4.13.4",
+    "html-webpack-plugin": "^2.16.1",
+    "rimraf": "^2.5.2",
+    "rollbar-sourcemap-webpack-plugin": "^1.0.4",
+    "webpack": "^1.13.0",
+    "webpack-dev-middleware": "^1.6.1",
+    "webpack-s3-plugin": "^0.7.2"
+  }
+}

--- a/examples/react/server/index.js
+++ b/examples/react/server/index.js
@@ -1,0 +1,27 @@
+// require('babel-register');
+
+// if (!process.env.NODE_ENV) {
+//   process.env.NODE_ENV = 'development';
+// }
+
+// if (process.env.NODE_ENV === 'development') {
+//   module.exports = require('./development');
+// } else {
+//   module.exports = require('./production');
+// }
+
+import express from 'express';
+import path from 'path';
+
+const app = express();
+const port = process.env.PORT || 8000;
+const index = path.join(__dirname, '../dist/index.html');
+
+app.use((req, res) => res.sendFile(index));
+
+app.listen(port, function(error) {
+  if (error) {
+    return console.error(error); // eslint-disable-line no-console
+  }
+  console.info(`==> Listening on port ${port}`); // eslint-disable-line no-console
+});

--- a/examples/react/src/components/App.js
+++ b/examples/react/src/components/App.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+
+class App extends Component {
+  render() {
+    try {
+      throw new Error('Something went wrong');
+    } catch (e) {
+      window.Rollbar.error(e);
+    }
+
+    return (
+      <div>RollbarSourceMapPlugin - React example</div>
+    );
+  }
+}
+
+export default App;

--- a/examples/react/src/index.html
+++ b/examples/react/src/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>RollbarSourcemapPlugin: React Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/react/src/index.js
+++ b/examples/react/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from 'react-dom';
+import App from './components/App';
+import rollbar from './rollbar';
+
+window.Rollbar = rollbar;
+
+render(<App />, document.getElementById('root'));

--- a/examples/react/src/rollbar.js
+++ b/examples/react/src/rollbar.js
@@ -1,0 +1,18 @@
+import rollbar from 'rollbar-browser/dist/rollbar.umd.nojson';
+
+export default rollbar.init({
+  accessToken: __ROLLBAR_ACCESS_TOKEN__,
+  captureUncaught: true,
+  payload: {
+    environment: process.env.NODE_ENV,
+    client: {
+      javascript: {
+        source_map_enabled: true,
+        code_version: __GIT_REVISION__,
+        // Optionally have Rollbar guess which frames the error was thrown from
+        // when the browser does not provide line and column numbers.
+        guess_uncaught_frames: true
+      }
+    }
+  }
+});

--- a/examples/react/webpack.config.babel.js
+++ b/examples/react/webpack.config.babel.js
@@ -1,0 +1,103 @@
+import path from 'path';
+import cp from 'child_process';
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import S3Plugin from 'webpack-s3-plugin';
+import RollbarSourcemapPlugin from 'rollbar-sourcemap-webpack-plugin';
+
+const rollbarClientAccessToken = 'd7c9872c2a11402ca2ddea52d115ce6b';
+const rollbarServerAccessToken = '79cc7ed367384b4bae9d19404069ae2c';
+const bucket = 'bdoran-rollbar-test';
+const s3Options = {
+  accessKeyId: 'AKIAJ5MMB3N2XROYW4AA',
+  secretAccessKey: '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',
+  region: 'us-west-1'
+};
+const basePath = 'assets';
+const publicPath = `https://s3-${s3Options.region}.amazonaws.com/${bucket}/${basePath}`;
+let version;
+try {
+  version = cp.execSync('git rev-parse HEAD', {
+    cwd: __dirname,
+    encoding: 'utf8'
+  });
+} catch (err) {
+  console.log('Error getting revision', err); // eslint-disable-line no-console
+  process.exit(1);
+}
+
+export default {
+  devtool: 'source-map',
+  entry: {
+    app: './src/index',
+    vendor: ['react', 'react-dom']
+  },
+  output: {
+    path: path.join(__dirname, 'dist'),
+    publicPath,
+    filename: '[name]-[chunkhash].js',
+    chunkFilename: '[name]-[chunkhash].js'
+  },
+  plugins: [
+    new webpack.NoErrorsPlugin(),
+    new webpack.optimize.OccurenceOrderPlugin(true),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: Infinity
+    }),
+    new webpack.DefinePlugin({
+      /* eslint-disable quote-props */
+      'process.env': {
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+      },
+      /* eslint-enable quote-props */
+      __ROLLBAR_ACCESS_TOKEN__: JSON.stringify(rollbarClientAccessToken),
+      __GIT_REVISION__: JSON.stringify(version)
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      },
+      mangle: false
+    }),
+    new HtmlWebpackPlugin({ template: 'src/index.html' }),
+    // Publish minified source
+    new S3Plugin({
+      include: /\.js$/,
+      basePath,
+      s3Options,
+      s3UploadOptions: {
+        Bucket: bucket,
+        ACL: 'public-read',
+        ContentType: 'application/javascript'
+      }
+    }),
+    // Publish sourcemap, but keep it private
+    new S3Plugin({
+      include: /\.map$/,
+      basePath: `${basePath}`,
+      s3Options,
+      s3UploadOptions: {
+        Bucket: bucket,
+        ACL: 'private',
+        ContentType: 'application/json'
+      }
+    }),
+    // Upload emitted sourcemaps to rollbar
+    new RollbarSourcemapPlugin({
+      accessToken: rollbarServerAccessToken,
+      version,
+      publicPath
+    })
+  ],
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loaders: ['babel'],
+        exclude: /node_modules/,
+        include: path.join(__dirname, 'src')
+      }
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm run -s clean",
     "build": "babel src -d dist",
     "build:watch": "watch 'npm run build' ./src",
-    "test": " cross-env NODE_ENV='test' nyc mocha --compilers js:babel-register",
+    "test": "cross-env NODE_ENV='test' nyc mocha --compilers js:babel-register",
     "test:watch": "npm test -- -w",
     "changelog": "npm run changelog:generate && npm run changelog:add",
     "changelog:add": "git add CHANGELOG.md",
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/brandondoran/rollbar-sourcemap-webpack-plugin.git"
+    "url": "https://github.com/brandondoran/rollbar-sourcemap-webpack-plugin.git"
   },
   "keywords": [
     "webpack",
@@ -30,6 +30,7 @@
     "rollbar",
     "source map",
     "sourcemap",
+    "sourcemaps",
     "production"
   ],
   "author": "Brandon Doran <bdoran@gmail.com>",


### PR DESCRIPTION
Add a minimal React app with webpack build. The app includes a local Express server that
serves an index.html. The build is meant to mimic a production build in that the
js bundles and sourcemaps are uploaded to AWS S3. The webpack config executes a
git rev-parse to get the commit sha to use as the code version to pass to rollbar.
In production this might not be what you need (git ls-remote maybe?).
You will need AWS and Rollbar accounts. To run the example:

  - Set your aws and rollbar options in `examples/react/webpack.config.babel.js`
  - `$ cd examples/react`
  - `$ npm run build`
  - `$ npm start`
  - open [http://localhost:8000](http://localhost:8000/)
  
  When the example app is loaded in a browser,
  the app will throw an error, which will be sent to Rollbar.
  You should be able to log in to Rollbar and see the error with stacktrace
  with line numbers that map to the original source.